### PR TITLE
Use DateTimeImmutable

### DIFF
--- a/src/Delivery.php
+++ b/src/Delivery.php
@@ -48,7 +48,7 @@ final class Delivery
         public readonly ?string $replyTo = null,
         public readonly ?string $expiration = null,
         public readonly ?string $messageId = null,
-        public readonly ?\DateTimeInterface $timestamp = null,
+        public readonly ?\DateTimeImmutable $timestamp = null,
         public readonly ?string $type = null,
         public readonly ?string $userId = null,
         public readonly ?string $appId = null,

--- a/src/Internal/Io/Buffer.php
+++ b/src/Internal/Io/Buffer.php
@@ -86,7 +86,7 @@ final class Buffer implements
         return $this;
     }
 
-    public function writeTimestamp(\DateTimeInterface $date): self
+    public function writeTimestamp(\DateTimeImmutable $date): self
     {
         $timestamp = $date->getTimestamp();
         \assert($timestamp >= 0);
@@ -129,7 +129,7 @@ final class Buffer implements
             \is_bool($value) => $this
                 ->writeUint8(Type::boolean->value)
                 ->writeUint8((int) $value),
-            $value instanceof \DateTimeInterface => $this
+            $value instanceof \DateTimeImmutable => $this
                 ->writeUint8(Type::timestamp->value)
                 ->writeTimestamp($value),
             $value === null => $this->writeUint8(Type::null->value),
@@ -217,7 +217,7 @@ final class Buffer implements
         return $this->endian->unpackDouble($this->consume(8));
     }
 
-    public function readTimestamp(): \DateTimeInterface
+    public function readTimestamp(): \DateTimeImmutable
     {
         return new \DateTimeImmutable(\sprintf('@%s', $this->readUint64()));
     }

--- a/src/Internal/Io/ReadBytes.php
+++ b/src/Internal/Io/ReadBytes.php
@@ -44,7 +44,7 @@ interface ReadBytes
     /**
      * @throws \Throwable
      */
-    public function readTimestamp(): \DateTimeInterface;
+    public function readTimestamp(): \DateTimeImmutable;
 
     public function readDecimal(): int;
 

--- a/src/Internal/Io/WriteBytes.php
+++ b/src/Internal/Io/WriteBytes.php
@@ -41,7 +41,7 @@ interface WriteBytes
 
     public function writeText(string $v): self;
 
-    public function writeTimestamp(\DateTimeInterface $date): self;
+    public function writeTimestamp(\DateTimeImmutable $date): self;
 
     /**
      * @param array<array-key, mixed> $values

--- a/src/Internal/MessageProperties.php
+++ b/src/Internal/MessageProperties.php
@@ -43,7 +43,7 @@ final class MessageProperties
         public readonly ?string $replyTo = null,
         public readonly ?string $expiration = null,
         public readonly ?string $messageId = null,
-        public readonly ?\DateTimeInterface $timestamp = null,
+        public readonly ?\DateTimeImmutable $timestamp = null,
         public readonly ?string $type = null,
         public readonly ?string $userId = null,
         public readonly ?string $appId = null,

--- a/src/Message.php
+++ b/src/Message.php
@@ -24,7 +24,7 @@ final class Message
         public readonly ?string $replyTo = null,
         public readonly ?string $expiration = null,
         public readonly ?string $messageId = null,
-        public readonly ?\DateTimeInterface $timestamp = null,
+        public readonly ?\DateTimeImmutable $timestamp = null,
         public readonly ?string $type = null,
         public readonly ?string $userId = null,
         public readonly ?string $appId = null,

--- a/tests/AmqpTest.php
+++ b/tests/AmqpTest.php
@@ -628,7 +628,7 @@ final class AmqpTest extends TestCase
         ?string $correlationId = null,
         ?string $expiration = null,
         ?string $messageId = null,
-        ?\DateTimeInterface $timestamp = null,
+        ?\DateTimeImmutable $timestamp = null,
         ?string $type = null,
         ?string $userId = null,
         ?string $appId = null,


### PR DESCRIPTION
I think we should force users switch to immutable date. If they have `DateTime`, they can always use `DateTimeImmutable::createFromMutable()` and `DateTimeImmutable::createFromInterface()`.