### PR TITLE
Allow concurrent and exclusive call to `DeliveryMessage::ack`, `DeliveryMessage::nack` or `DeliveryMessage::reject`

### DIFF
--- a/tests/DeliveryMessageTest.php
+++ b/tests/DeliveryMessageTest.php
@@ -7,6 +7,8 @@ namespace Thesis\Amqp;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
+use function Amp\async;
+use function Amp\Future\awaitAll;
 
 #[CoversClass(DeliveryMessage::class)]
 final class DeliveryMessageTest extends TestCase
@@ -37,9 +39,13 @@ final class DeliveryMessageTest extends TestCase
             'reject' => $delivery->reject(...),
         };
 
+        $futures = [];
+
         for ($i = 0; $i < 10; ++$i) {
-            $call();
+            $futures[] = async($call);
         }
+
+        awaitAll($futures);
 
         self::assertSame(1, $count);
     }

--- a/tests/DeliveryMessageTest.php
+++ b/tests/DeliveryMessageTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Thesis\Amqp;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DeliveryMessage::class)]
+final class DeliveryMessageTest extends TestCase
+{
+    /**
+     * @param 'ack'|'nack'|'reject' $operationType
+     */
+    #[TestWith(['ack'])]
+    #[TestWith(['nack'])]
+    #[TestWith(['reject'])]
+    public function testRepetitiveOperation(string $operationType): void
+    {
+        $count = 0;
+        $operation = static function () use (&$count): void {
+            ++$count;
+        };
+
+        $delivery = new DeliveryMessage(
+            ack: $operation,
+            nack: $operation,
+            reject: $operation,
+            message: new Message('x'),
+        );
+
+        $call = match ($operationType) {
+            'ack' => $delivery->ack(...),
+            'nack' => $delivery->nack(...),
+            'reject' => $delivery->reject(...),
+        };
+
+        for ($i = 0; $i < 10; ++$i) {
+            $call();
+        }
+
+        self::assertSame(1, $count);
+    }
+}


### PR DESCRIPTION
Closes #9 