### PR TITLE
FIX: same count method in watermark().

### DIFF
--- a/src/ConsumeBatch.php
+++ b/src/ConsumeBatch.php
@@ -50,6 +50,6 @@ final class ConsumeBatch implements
 
     private function watermark(): DeliveryMessage
     {
-        return $this->deliveries[\count($this->deliveries) - 1];
+        return $this->deliveries[$this->count() - 1];
     }
 }


### PR DESCRIPTION
Use one method to count deliveries in waterwark. 